### PR TITLE
Fixed pusher POST endpoint url for receiving 404

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const dispatch = function(body, type = 'events') {
 
     const queryString = qs.stringify(params);
 
-    return axios.post(`http://api-${this.cluster}.pusher.com/${path}?${queryString}&auth_signature=${sha256.hmac(this.secret, ['POST', path, queryString].join('\n'))}`, body);
+    return axios.post(`http://api-${this.cluster}.pusher.com${path}?${queryString}&auth_signature=${sha256.hmac(this.secret, ['POST', path, queryString].join('\n'))}`, body);
 };
 
 Pusher.prototype.trigger = trigger;


### PR DESCRIPTION
Good morning!!!

Around 1 week ago, we stared receiving a 404 from Pusher using your library. The issue was a double "//" in the request url. I already fixed and tested thought lambda functions. Please review my changes. Thanks

Best

Victor